### PR TITLE
refactor #131 cards_abstracting_functionality

### DIFF
--- a/exercises/php/cards/Animal.php
+++ b/exercises/php/cards/Animal.php
@@ -4,33 +4,17 @@ namespace McrDigital\PhpFundamentals1\Cards;
 
 class Animal
 {
-    public array $animal = [
-        "AARDVARK",
-        "BABOON",
-        "CAMEL",
-        "DEER",
-        "ELEPHANT",
-        "FROG",
-        "GORILLA",
-        "HARE",
-        "IMPALA",
-        "JAGUAR",
-        "KANGAROO",
-        "LION",
-        "MOOSE",
-        "NEWT",
-        "OCTOPUS",
-        "PENGUIN",
-        "QUETZAL",
-        "RABBIT",
-        "SALMON",
-        "TORTOISE",
-        "UAKARIS",
-        "VAQUITA",
-        "WHALE",
-        "X_RAY_TETRA",
-        "YAK",
-        "ZEBRA"
-    ];
+    private string $animalName;
+
+    public function __construct(string $animalName)
+    {
+        $this->animalName = $animalName;
+    }
+
+    public function __toString(): string
+    {
+        return $this->animalName;
+    }
+
 
 }

--- a/exercises/php/cards/AnimalCard.php
+++ b/exercises/php/cards/AnimalCard.php
@@ -6,16 +6,16 @@ use Exception;
 
 class AnimalCard implements Card
 {
-    private string $animal;
+    private Animal $animal;
 
-    public function __construct(string $animal)
+    public function __construct(Animal $animal)
     {
         $this->animal = $animal;
     }
 
     public function __toString(): string
     {
-        return $this->animal;
+        return strval($this->animal);
     }
 
     public function snap(?Card $card): bool

--- a/exercises/php/cards/AnimalDeck.php
+++ b/exercises/php/cards/AnimalDeck.php
@@ -10,10 +10,9 @@ class AnimalDeck implements Deck
     {
         $this->cards = [];
 
-        $cAnimal = new Animal();
-        foreach ($cAnimal->animal as $animal) {
-            $this->cards[] = new AnimalCard($animal);
-            $this->cards[] = new AnimalCard($animal);
+        foreach (Animals::ANIMALS as $animal) {
+            $this->cards[] = new AnimalCard(new Animal($animal));
+            $this->cards[] = new AnimalCard(new Animal($animal));
         }
     }
 

--- a/exercises/php/cards/Animals.php
+++ b/exercises/php/cards/Animals.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace McrDigital\PhpFundamentals1\Cards;
+
+class Animals
+{
+    public const ANIMALS = [
+        "AARDVARK",
+        "BABOON",
+        "CAMEL",
+        "DEER",
+        "ELEPHANT",
+        "FROG",
+        "GORILLA",
+        "HARE",
+        "IMPALA",
+        "JAGUAR",
+        "KANGAROO",
+        "LION",
+        "MOOSE",
+        "NEWT",
+        "OCTOPUS",
+        "PENGUIN",
+        "QUETZAL",
+        "RABBIT",
+        "SALMON",
+        "TORTOISE",
+        "UAKARIS",
+        "VAQUITA",
+        "WHALE",
+        "X_RAY_TETRA",
+        "YAK",
+        "ZEBRA"
+    ];
+
+}

--- a/exercises/php/cards/PlayingCard.php
+++ b/exercises/php/cards/PlayingCard.php
@@ -6,10 +6,10 @@ use Exception;
 
 class PlayingCard implements Card
 {
-    private string $suit;
+    private Suit $suit;
     private int $faceValue;
 
-    public function __construct(string $suit, int $faceValue)
+    public function __construct(Suit $suit, int $faceValue)
     {
         $this->suit = $suit;
         $this->faceValue = $faceValue;
@@ -57,7 +57,7 @@ class PlayingCard implements Card
 
     public function getSuit(): string
     {
-        return $this->suit;
+        return strval($this->suit);
     }
 
     public function snap(?Card $card): bool

--- a/exercises/php/cards/PlayingCardDeck.php
+++ b/exercises/php/cards/PlayingCardDeck.php
@@ -8,12 +8,11 @@ class PlayingCardDeck implements Deck
 
     public function __construct()
     {
-        $cSuits = new Suit();
         $this->cards = [];
 
-        foreach ($cSuits->suit as $suit) {
+        foreach (Suits::SUITS as $suit) {
             for ($faceValue = 0; $faceValue < 13; $faceValue++) {
-                $this->cards[] = new PlayingCard($suit, $faceValue);
+                $this->cards[] = new PlayingCard(new Suit($suit), $faceValue);
             }
         }
     }

--- a/exercises/php/cards/Suit.php
+++ b/exercises/php/cards/Suit.php
@@ -4,11 +4,16 @@ namespace McrDigital\PhpFundamentals1\Cards;
 
 class Suit
 {
-    public array $suit = [
-        "clubs",
-        "diamonds",
-        "hearts",
-        "spades"
-    ];
+    private string $suitName;
+
+    public function __construct(string $suitName)
+    {
+        $this->suitName = $suitName;
+    }
+
+    public function __toString(): string
+    {
+        return $this->suitName;
+    }
 
 }

--- a/exercises/php/cards/Suits.php
+++ b/exercises/php/cards/Suits.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace McrDigital\PhpFundamentals1\Cards;
+
+class Suits
+{
+    public const SUITS = [
+        "clubs",
+        "diamonds",
+        "hearts",
+        "spades"
+    ];
+
+}

--- a/exercises/php/tests/cards/AnimalDeckTest.php
+++ b/exercises/php/tests/cards/AnimalDeckTest.php
@@ -32,10 +32,9 @@ class AnimalDeckTest extends TestCase
 
     protected function setUp(): void
     {
-        $cAnimal = new Animal();
-        foreach ($cAnimal->animal as $animal) {
-            $this->testCards[] = new AnimalCard($animal);
-            $this->testCards[] = new AnimalCard($animal);
+        foreach (Animals::ANIMALS as $animal) {
+            $this->testCards[] = new AnimalCard(new Animal($animal));
+            $this->testCards[] = new AnimalCard(new Animal($animal));
         }
     }
 


### PR DESCRIPTION
Changes for #131 to strongly type XCard members as the type of card they represent, e.g. Animal etc.

@mrmanc Let me know if this is on the right lines of what you were thinking for #131, I will update the other solutions as appropriate when you're happy (potentially `master` to update `Animal` classes too) :)